### PR TITLE
[build] make packages "stable"

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>6.0.0-preview2</PackageVersion>
+    <PackageVersion>6.0.0</PackageVersion>
     <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Support for the Mono profiler in .NET 6 Android applications
 
 ```dotnetcli
 > dotnet new android
-> dotnet add package Mono.Profiler.Android --prerelease
+> dotnet add package Mono.Profiler.Android
 > dotnet build -c Release -t:StartProfiling
 # Wait until app launches, or you navigate to a screen
 > dotnet build -c Release -t:StopProfiling
@@ -24,7 +24,7 @@ See [Profiling Managed Code][profiling] for more info.
 Use a Debug build, or set `-p:AndroidEnableAotProfiler=true`:
 
 ```dotnetcli
-> dotnet add package Mono.AotProfiler.Android --prerelease
+> dotnet add package Mono.AotProfiler.Android
 > dotnet build -t:BuildAndStartAotProfiling
 # Wait until app launches, or you navigate to a screen
 > dotnet build -t:FinishAotProfiling

--- a/src/Mono.AotProfiler.Android/Mono.AotProfiler.Android.csproj
+++ b/src/Mono.AotProfiler.Android/Mono.AotProfiler.Android.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU5128</NoWarn>
-    <Description>Support for recording custom AOT profiles in .NET 6 Android applications</Description>
+    <Description>Experimental support for recording custom AOT profiles in .NET 6 Android applications</Description>
     <PackageProjectUrl>https://github.com/jonathanpeppers/Mono.Profiler.Android</PackageProjectUrl>
     <PackageTags>Xamarin .NET 6 Mono AOT Profiler Android</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Mono.Profiler.Android/Mono.Profiler.Android.csproj
+++ b/src/Mono.Profiler.Android/Mono.Profiler.Android.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU5128</NoWarn>
-    <Description>Support for the Mono profiler in .NET 6 Android applications</Description>
+    <Description>Experimental support for the Mono profiler in .NET 6 Android applications</Description>
     <PackageProjectUrl>https://github.com/jonathanpeppers/Mono.Profiler.Android</PackageProjectUrl>
     <PackageTags>Xamarin .NET 6 Mono Profiler Android</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
These packages are experimental, but let's drop the `-preview` suffix.

I want to release .NET 7 versions of these shortly, and those will have `-preview`.