### PR TITLE
Drop `-preview` suffix for 9.0 package

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>9.0.0-preview1</PackageVersion>
+    <PackageVersion>9.0.0</PackageVersion>
     <OutputPath>$(MSBuildThisFileDirectory)bin/$(Configuration)/</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
Doing a PR, as I don't know if CI is still working.